### PR TITLE
Use an empty environment before sourcing

### DIFF
--- a/lib/accel_cmd_processor/sw/core0/Makefile
+++ b/lib/accel_cmd_processor/sw/core0/Makefile
@@ -77,7 +77,7 @@ SYS_OBJ = $(SYS_SRC:$(SYSTEM_DIR)%.c=$(OBJ_DIR)%.o)
 # this line sources the configuration file, prints out the environment of the
 # child process, converts the bash sytnax to make syntax and stores the
 # variables in the file makeenv
-IGNORE := $(shell bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
+IGNORE := $(shell env -i bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
 include .makeenv
 
 # depends on the application and the elf binary

--- a/lib/fpga_cmd_processor/sw/core/Makefile
+++ b/lib/fpga_cmd_processor/sw/core/Makefile
@@ -69,7 +69,7 @@ SYS_OBJ = $(SYS_SRC:$(SYSTEM_DIR)%.c=$(OBJ_DIR)%.o)
 # this line sources the configuration file, prints out the environment of the
 # child process, converts the bash sytnax to make syntax and stores the
 # variables in the file makeenv
-IGNORE := $(shell bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
+IGNORE := $(shell env -i bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
 include .makeenv
 
 # depends on the application and the elf binary

--- a/lib/packet_processor/sw/core/Makefile
+++ b/lib/packet_processor/sw/core/Makefile
@@ -64,12 +64,12 @@ SYS_OBJ = $(SYS_SRC:$(SYSTEM_DIR)%.c=$(OBJ_DIR)%.o)
 .PHONY: clean application
 
 .SECONDARY: $(ASM) $(SYS_ASM)
-
+#-0 | tr '\\n' '\\t' | tr '\\0' '\\n' | sed 's/^.*\\t.*$//' | sed '/^$/d' |
 # make starts everything in a child process
 # this line sources the configuration file, prints out the environment of the
 # child process, converts the bash sytnax to make syntax and stores the
 # variables in the file makeenv
-IGNORE := $(shell bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
+IGNORE := $(shell env -i bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
 include .makeenv
 
 # depends on the application and the elf binary

--- a/lib/rom_accel_cmd_processor/sw/core0/Makefile
+++ b/lib/rom_accel_cmd_processor/sw/core0/Makefile
@@ -77,7 +77,7 @@ SYS_OBJ = $(SYS_SRC:$(SYSTEM_DIR)%.c=$(OBJ_DIR)%.o)
 # this line sources the configuration file, prints out the environment of the
 # child process, converts the bash sytnax to make syntax and stores the
 # variables in the file makeenv
-IGNORE := $(shell bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
+IGNORE := $(shell env -i bash -c "source conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
 include .makeenv
 
 # depends on the application and the elf binary

--- a/tools/packet_tools/Makefile
+++ b/tools/packet_tools/Makefile
@@ -26,7 +26,7 @@ PROGS = $(patsubst %.cpp,%,$(SRCS))
 # this line sources the configuration file, prints out the environment of the
 # child process, converts the bash sytnax to make syntax and stores the
 # variables in the file makeenv
-IGNORE := $(shell bash -c "source ../../global_conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
+IGNORE := $(shell env -i bash -c "source ../../global_conf.sh; env | sed 's/=/:=/' | sed 's/^/export /' > .makeenv")
 include .makeenv
 
 # depends on the binary


### PR DESCRIPTION
    - Avoids errors due to e.g. newlines in the users bash configuration